### PR TITLE
Fix workflow to include CONTRIBUTING.md and README.md in git add

### DIFF
--- a/.github/workflows/registration-automation.yml
+++ b/.github/workflows/registration-automation.yml
@@ -124,8 +124,10 @@ jobs:
           git fetch origin main
           git merge origin/main --no-edit || true
 
-          # Only add registration files to avoid conflicts with submission workflow
+          # Add registration files and updated documentation
           git add registration/
+          git add CONTRIBUTING.md
+          git add README.md
           # Only commit when there are changes
           if git diff --staged --quiet; then
             echo "No changes to commit"

--- a/.github/workflows/submission-automation.yml
+++ b/.github/workflows/submission-automation.yml
@@ -123,8 +123,9 @@ jobs:
           git fetch origin main
           git merge origin/main --no-edit || true
 
-          # Only add submission files to avoid conflicts with registration workflow
+          # Add submission files and updated documentation
           git add submissions/
+          git add README.md
 
           # Check if there are changes to commit
           if git diff --staged --quiet; then


### PR DESCRIPTION
The scripts correctly update CONTRIBUTING.md (registration table) and README.md (submission table and statistics), but the workflows only added the registration/ and submissions/ directories.

This fix ensures the documentation files are also committed.